### PR TITLE
Fix AddressBook and RoleRequirement Equality

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -158,9 +158,19 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddressBook)) {
+            return false;
+        }
+
+        AddressBook otherAddressBook = (AddressBook) other;
+        return persons.equals(otherAddressBook.persons)
+                && shifts.equals(otherAddressBook.shifts);
+
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -186,7 +186,8 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+                && filteredPersons.equals(other.filteredPersons)
+                && filteredShifts.equals(other.filteredShifts);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,7 +1,5 @@
 package seedu.address.model;
 
-import java.util.List;
-
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.shift.Shift;

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -17,5 +17,5 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
-    List<Shift> getShiftList();
+    ObservableList<Shift> getShiftList();
 }

--- a/src/main/java/seedu/address/model/shift/RoleRequirement.java
+++ b/src/main/java/seedu/address/model/shift/RoleRequirement.java
@@ -80,7 +80,7 @@ public class RoleRequirement {
         return other == this
                 || (other instanceof RoleRequirement
                 && role.equals(((RoleRequirement) other).role)
-                && role.equals(((RoleRequirement) other).quantity));
+                && quantity == ((RoleRequirement) other).quantity);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/shift/ShiftDayOrTimeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/shift/ShiftDayOrTimeContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.shift;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Shift}'s {@code ShiftDay} or {@code ShiftTime} matches any of the keywords given.
+ */
+public class ShiftDayOrTimeContainsKeywordsPredicate implements Predicate<Shift> {
+    private final List<String> keywords;
+
+    public ShiftDayOrTimeContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Shift shift) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(shift.getShiftDay().toString(), keyword)
+                        && StringUtil.containsWordIgnoreCase(shift.getShiftTime().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof ShiftDayOrTimeContainsKeywordsPredicate
+                && keywords.equals(((ShiftDayOrTimeContainsKeywordsPredicate) other).keywords));
+    }
+}

--- a/src/main/java/seedu/address/model/shift/ShiftDayOrTimeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/shift/ShiftDayOrTimeContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class ShiftDayOrTimeContainsKeywordsPredicate implements Predicate<Shift>
     public boolean test(Shift shift) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(shift.getShiftDay().toString(), keyword)
-                        && StringUtil.containsWordIgnoreCase(shift.getShiftTime().toString(), keyword));
+                        || StringUtil.containsWordIgnoreCase(shift.getShiftTime().toString(), keyword));
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
+  "_comment": "AddressBook save file which contains the same Person values as in AddressBookBuilder#getTypicalAddressBook()",
   "persons" : [ {
     "name" : "Alice Pauline",
     "phone" : "94351253",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -43,5 +43,32 @@
     "address" : "4th street",
     "roles" : [ ]
   } ],
-  "shifts": []
+  "shifts" : [ {
+    "day" : "MON",
+    "time" : "AM",
+    "roleRequirements" : [ {
+      "role" : "cashier",
+      "quantity" : 1
+    } ]
+  }, {
+    "day" : "MON",
+    "time" : "PM",
+    "roleRequirements" : [ {
+      "role" : "cashier",
+      "quantity" : 1
+    }, {
+      "role" : "chef",
+      "quantity" : 3
+    } ]
+  }, {
+    "day": "TUE",
+    "time": "AM",
+    "roleRequirements" : [ {
+      "role" : "cleaner",
+      "quantity" : 4
+    }, {
+      "role": "cashier",
+      "quantity" : 3
+    } ]
+  } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -67,6 +67,13 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
+    public static final String VALID_DAY_MON = "MON";
+    public static final String VALID_DAY_TUE = "TUE";
+    public static final String VALID_TIME_AM = "AM";
+    public static final String VALID_TIME_PM = "PM";
+    public static final String VALID_ROLE_REQUIREMENT_CASHIER = VALID_ROLE_CASHIER + " 1";
+    public static final String VALID_ROLE_REQUIREMENT_CHEF = VALID_ROLE_CHEF + " 3";
+
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withPay(VALID_PAY_AMY).withAddress(VALID_ADDRESS_AMY)

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -10,9 +10,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_CASHIER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -12,7 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
-import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_CASHIER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_REQUIREMENT_CHEF;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalShifts.SHIFT_A;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,10 +20,13 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.shift.Shift;
+import seedu.address.model.shift.exceptions.DuplicateShiftException;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.ShiftBuilder;
 
 public class AddressBookTest {
 
@@ -30,6 +35,7 @@ public class AddressBookTest {
     @Test
     public void constructor() {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
+        assertEquals(Collections.emptyList(), addressBook.getShiftList());
     }
 
     @Test
@@ -50,7 +56,7 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withRoles(VALID_ROLE_CASHIER)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newPersons);
+        AddressBookStub newData = AddressBookStub.createAddressBookStubWithPersons(newPersons);
 
         assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
     }
@@ -84,6 +90,45 @@ public class AddressBookTest {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
     }
 
+    @Test
+    public void resetData_withDuplicateShifts_throwsDuplicateShiftException() {
+        Shift editedShift = new ShiftBuilder(SHIFT_A).withRoleRequirements(VALID_ROLE_REQUIREMENT_CHEF)
+                .build();
+        List<Shift> newShifts = Arrays.asList(SHIFT_A, editedShift);
+        AddressBookStub newData = AddressBookStub.createAddressBookStubWithShifts(newShifts);
+
+        assertThrows(DuplicateShiftException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void hasShift_nullShift_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasShift(null));
+    }
+
+    @Test
+    public void hasShift_shiftNotInAddressBook_returnsFalse() {
+        assertFalse(addressBook.hasShift(SHIFT_A));
+    }
+
+    @Test
+    public void hasShift_shiftInAddressBook_returnsTrue() {
+        addressBook.addShift(SHIFT_A);
+        assertTrue(addressBook.hasShift(SHIFT_A));
+    }
+
+    @Test
+    public void hasShift_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
+        addressBook.addShift(SHIFT_A);
+        Shift editedShift = new ShiftBuilder(SHIFT_A).withRoleRequirements(VALID_ROLE_REQUIREMENT_CHEF)
+                .build();
+        assertTrue(addressBook.hasShift(editedShift));
+    }
+
+    @Test
+    public void getShiftList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> addressBook.getShiftList().remove(0));
+    }
+
     /**
      * A stub ReadOnlyAddressBook whose persons list can violate interface constraints.
      */
@@ -92,8 +137,17 @@ public class AddressBookTest {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
         private final ObservableList<Shift> shifts = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Person> persons) {
+        private AddressBookStub(Collection<Person> persons, Collection<Shift> shifts) {
             this.persons.setAll(persons);
+            this.shifts.setAll(shifts);
+        }
+
+        public static AddressBookStub createAddressBookStubWithPersons(Collection<Person> persons) {
+            return new AddressBookStub(persons, Collections.EMPTY_LIST);
+        }
+
+        public static AddressBookStub createAddressBookStubWithShifts(Collection<Shift> shifts) {
+            return new AddressBookStub(Collections.EMPTY_LIST, shifts);
         }
 
         @Override

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_CASHIER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_REQUIREMENT_CHEF;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalShifts.SHIFT_A;
 
 import java.util.Arrays;
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.shift.Shift;
@@ -100,6 +99,7 @@ public class AddressBookTest {
         assertThrows(DuplicateShiftException.class, () -> addressBook.resetData(newData));
     }
 
+
     @Test
     public void hasShift_nullShift_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> addressBook.hasShift(null));
@@ -129,10 +129,10 @@ public class AddressBookTest {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getShiftList().remove(0));
     }
 
+
     /**
      * A stub ReadOnlyAddressBook whose persons list can violate interface constraints.
      */
-    //Todo: include shift based tests, then fully implement shift in this stub
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
         private final ObservableList<Shift> shifts = FXCollections.observableArrayList();
@@ -143,12 +143,13 @@ public class AddressBookTest {
         }
 
         public static AddressBookStub createAddressBookStubWithPersons(Collection<Person> persons) {
-            return new AddressBookStub(persons, Collections.EMPTY_LIST);
+            return new AddressBookStub(persons, Collections.emptyList());
         }
 
         public static AddressBookStub createAddressBookStubWithShifts(Collection<Shift> shifts) {
-            return new AddressBookStub(Collections.EMPTY_LIST, shifts);
+            return new AddressBookStub(Collections.emptyList(), shifts);
         }
+
 
         @Override
         public ObservableList<Person> getPersonList() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -154,7 +154,7 @@ public class ModelManagerTest {
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         //different filteredShiftList -> returns false
-        List<String> shiftKeywords = Arrays.asList(SHIFT_A.getShiftDay().toString(), SHIFT_A.getShiftTime().toString());
+        List<String> shiftKeywords = Arrays.asList(SHIFT_A.getShiftTime().toString());
         modelManager.updateFilteredShiftList(new ShiftDayOrTimeContainsKeywordsPredicate(shiftKeywords));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -4,18 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SHIFTS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalShifts.SHIFT_A;
+import static seedu.address.testutil.TypicalShifts.SHIFT_B;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.shift.ShiftDayOrTimeContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -94,8 +99,32 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasShift_nullShift_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasShift(null));
+    }
+
+    @Test
+    public void hasShift_shiftNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasShift(SHIFT_A));
+    }
+
+    @Test
+    public void hasShift_shiftInAddressBook_returnsTrue() {
+        modelManager.addShift(SHIFT_A);
+        assertTrue(modelManager.hasShift(SHIFT_A));
+    }
+
+    @Test
+    public void getFilteredShiftList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredShiftList().remove(0));
+    }
+
+    @Test
     public void equals() {
-        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        AddressBook addressBook = new AddressBookBuilder()
+                .withPerson(ALICE).withPerson(BENSON)
+                .withShift(SHIFT_A).withShift(SHIFT_B)
+                .build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -116,13 +145,21 @@ public class ModelManagerTest {
         // different addressBook -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
-        // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        // different filteredPersonList -> returns false
+        String[] personKeywords = ALICE.getName().fullName.split("\\s+");
+        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(personKeywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        //different filteredShiftList -> returns false
+        List<String> shiftKeywords = Arrays.asList(SHIFT_A.getShiftDay().toString(), SHIFT_A.getShiftTime().toString());
+        modelManager.updateFilteredShiftList(new ShiftDayOrTimeContainsKeywordsPredicate(shiftKeywords));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
+        //resets modelManager to initial state
+        modelManager.updateFilteredShiftList(PREDICATE_SHOW_ALL_SHIFTS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -6,7 +6,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.IDA;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -2,11 +2,11 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.IDA;
-import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.TypicalPersons;
+import seedu.address.testutil.AddressBookBuilder;
 
 public class JsonSerializableAddressBookTest {
 
@@ -25,7 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        AddressBook typicalPersonsAddressBook = AddressBookBuilder.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 
 import java.nio.file.Path;
 

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -43,6 +43,14 @@ public class AddressBookBuilder {
         return this;
     }
 
+    /**
+     * Adds a new {@code Shift} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withShift(Shift shift) {
+        addressBook.addShift(shift);
+        return this;
+    }
+
     public AddressBook build() {
         return addressBook;
     }

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -2,6 +2,7 @@ package seedu.address.testutil;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.shift.Shift;
 
 /**
  * A utility class to help with building Addressbook objects.
@@ -18,6 +19,20 @@ public class AddressBookBuilder {
 
     public AddressBookBuilder(AddressBook addressBook) {
         this.addressBook = addressBook;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Person person : TypicalPersons.getTypicalPersons()) {
+            ab.addPerson(person);
+        }
+        for (Shift shift : TypicalShifts.getTypicalShifts()) {
+            ab.addShift(shift);
+        }
+        return ab;
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/ShiftBuilder.java
+++ b/src/test/java/seedu/address/testutil/ShiftBuilder.java
@@ -1,0 +1,71 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.shift.RoleRequirement;
+import seedu.address.model.shift.Shift;
+import seedu.address.model.shift.ShiftDay;
+import seedu.address.model.shift.ShiftTime;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Shift objects.
+ */
+public class ShiftBuilder {
+
+    public static final String DEFAULT_DAY = "MON";
+    public static final String DEFAULT_TIME = "AM";
+
+    private ShiftDay day;
+    private ShiftTime time;
+    private Set<RoleRequirement> roleRequirements;
+
+    /**
+     * Creates a {@code ShiftBuilder} with the default details.
+     */
+    public ShiftBuilder() {
+        day = new ShiftDay(DEFAULT_DAY);
+        time = new ShiftTime(DEFAULT_TIME);
+        roleRequirements = new HashSet<>();
+    }
+
+    /**
+     * Initializes the ShiftBuilder with the data of {@code shiftToCopy}.
+     */
+    public ShiftBuilder(Shift shiftToCopy) {
+        day = shiftToCopy.getShiftDay();
+        time = shiftToCopy.getShiftTime();
+        roleRequirements = new HashSet<>(shiftToCopy.getRoleRequirements());
+    }
+
+    /**
+     * Sets the {@code ShiftDay} of the {@code Shift} that we are building.
+     */
+    public ShiftBuilder withShiftDay(String day) {
+        this.day = new ShiftDay(day);
+        return this;
+    }
+
+    /**
+     * Sets the {@code ShiftTime} of the {@code Shift} that we are building.
+     */
+    public ShiftBuilder withShiftTime(String time) {
+        this.time = new ShiftTime(time);
+        return this;
+    }
+
+    /**
+     * Parses the {@code roleRequirements} into a {@code Set<RoleRequirements>} and set it to the {@code Shift} that
+     * we are building.
+     */
+    public ShiftBuilder withRoleRequirements(String ... roleRequirements) {
+        this.roleRequirements = SampleDataUtil.getRoleRequirementSet(roleRequirements);
+        return this;
+    }
+
+    public Shift build() {
+        return new Shift(day, time, roleRequirements);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -61,17 +61,6 @@ public class TypicalPersons {
 
     private TypicalPersons() {} // prevents instantiation
 
-    /**
-     * Returns an {@code AddressBook} with all the typical persons.
-     */
-    public static AddressBook getTypicalAddressBook() {
-        AddressBook ab = new AddressBook();
-        for (Person person : getTypicalPersons()) {
-            ab.addPerson(person);
-        }
-        return ab;
-    }
-
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -2,8 +2,6 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-//import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-//import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PAY_AMY;
@@ -17,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
 
 /**

--- a/src/test/java/seedu/address/testutil/TypicalShifts.java
+++ b/src/test/java/seedu/address/testutil/TypicalShifts.java
@@ -1,0 +1,29 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.shift.Shift;
+
+/**
+ * A utility class containing a list of {@code Shift} objects to be used in tests.
+ */
+public class TypicalShifts {
+
+    public static final Shift SHIFT_A = new ShiftBuilder().withShiftDay("MON")
+            .withShiftTime("AM")
+            .withRoleRequirements("cashier 1").build();
+    public static final Shift SHIFT_B = new ShiftBuilder().withShiftDay("MON")
+            .withShiftTime("PM")
+            .withRoleRequirements("cashier 1", "chef 3").build();
+    public static final Shift SHIFT_C = new ShiftBuilder().withShiftDay("TUE")
+            .withShiftTime("AM")
+            .withRoleRequirements("cleaner 4", "cashier 3").build();
+
+    public static List<Shift> getTypicalShifts() {
+        return new ArrayList<>(Arrays.asList(SHIFT_A, SHIFT_B, SHIFT_C));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalShifts.java
+++ b/src/test/java/seedu/address/testutil/TypicalShifts.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.shift.Shift;
 
 /**


### PR DESCRIPTION
The following bugs were fixed:
- `AddressBook.equals()` now compares `shifts` correctly.
- `RoleRequirement.equals()` now compares `quantity` correctly.

This PR also adds some tests for `AddressBook` and `ModelManager`.

Contributes to #43 