### PR TITLE
Prevent Leave role from being modified through role-add

### DIFF
--- a/src/main/java/mcscheduler/logic/commands/RoleAddCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/RoleAddCommand.java
@@ -33,7 +33,7 @@ public class RoleAddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasRole(toAdd)) {
-            if (toAdd.equals(new Leave())) {
+            if (Leave.isLeave(toAdd)) {
                 throw new CommandException(MESSAGE_DO_NOT_MODIFY_LEAVE);
             }
             throw new CommandException(MESSAGE_DUPLICATE_ROLE);

--- a/src/main/java/mcscheduler/logic/commands/RoleAddCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/RoleAddCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import mcscheduler.logic.commands.exceptions.CommandException;
 import mcscheduler.model.Model;
+import mcscheduler.model.role.Leave;
 import mcscheduler.model.role.Role;
 
 /**
@@ -15,6 +16,7 @@ public class RoleAddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New role added: %1$s";
     public static final String MESSAGE_DUPLICATE_ROLE = "This role already exists in the McScheduler";
+    public static final String MESSAGE_DO_NOT_MODIFY_LEAVE = "Leave role is a system default and should not be added.";
 
     private final Role toAdd;
 
@@ -31,6 +33,9 @@ public class RoleAddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasRole(toAdd)) {
+            if (toAdd.equals(new Leave())) {
+                throw new CommandException(MESSAGE_DO_NOT_MODIFY_LEAVE);
+            }
             throw new CommandException(MESSAGE_DUPLICATE_ROLE);
         }
 

--- a/src/main/java/mcscheduler/logic/commands/RoleDeleteCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/RoleDeleteCommand.java
@@ -13,6 +13,7 @@ import mcscheduler.commons.util.CollectionUtil;
 import mcscheduler.logic.commands.exceptions.CommandException;
 import mcscheduler.model.Model;
 import mcscheduler.model.assignment.Assignment;
+import mcscheduler.model.role.Leave;
 import mcscheduler.model.role.Role;
 import mcscheduler.model.shift.RoleRequirement;
 import mcscheduler.model.shift.Shift;
@@ -49,6 +50,8 @@ public class RoleDeleteCommand extends Command {
         }
 
         Role roleToDelete = roleList.get(targetIndex.getZeroBased());
+        assert !roleToDelete.equals(new Leave());
+
         deleteRoleFromShifts(model, roleToDelete);
         deleteRoleFromWorkers(model, roleToDelete);
         deleteRoleFromAssignments(model, roleToDelete);

--- a/src/main/java/mcscheduler/logic/commands/RoleDeleteCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/RoleDeleteCommand.java
@@ -50,7 +50,7 @@ public class RoleDeleteCommand extends Command {
         }
 
         Role roleToDelete = roleList.get(targetIndex.getZeroBased());
-        assert !roleToDelete.equals(new Leave());
+        assert !Leave.isLeave(roleToDelete);
 
         deleteRoleFromShifts(model, roleToDelete);
         deleteRoleFromWorkers(model, roleToDelete);

--- a/src/main/java/mcscheduler/model/role/Role.java
+++ b/src/main/java/mcscheduler/model/role/Role.java
@@ -25,7 +25,7 @@ public class Role {
      * Factory method for creating a {@code Role}. Returns a {@code Leave} if {@code roleName} is {@code "Leave"}.
      */
     public static Role createRole(String roleName) {
-        if (roleName.equals(Leave.ROLE_NAME)) {
+        if (roleName.equalsIgnoreCase(Leave.ROLE_NAME)) {
             return new Leave();
         }
         return new Role(roleName);


### PR DESCRIPTION
Resolves #200 by adding a new error message if a Leave is parsed in `role-add`.