### PR TITLE
Add 'reassign s/ w/ r/' command

### DIFF
--- a/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
@@ -118,10 +118,12 @@ public class ReassignCommand extends Command {
         }
 
         if (!newWorker.isFitForRole(newRole)) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_WORKER_ROLE);
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_ASSIGNMENT_WORKER_ROLE,
+                    newWorker.getName(), newRole));
         }
         if (newWorker.isUnavailable(newShift)) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_UNAVAILABLE);
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_ASSIGNMENT_UNAVAILABLE,
+                    newWorker.getName(), newShift));
         }
 
         if (!newShift.isRoleRequired(newRole)) {

--- a/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
@@ -2,8 +2,10 @@ package mcscheduler.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_ROLE;
+import static mcscheduler.logic.parser.CliSyntax.PREFIX_SHIFT;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_SHIFT_NEW;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_SHIFT_OLD;
+import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_NEW;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_OLD;
 
@@ -24,18 +26,22 @@ public class ReassignCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits an assignment in the "
             + "McScheduler by the index numbers used in the last worker and shift listings. "
-            + "\nParameters: "
-            + PREFIX_WORKER_OLD + "OLD_WORKER_INDEX (must be a positive integer) "
+            + "\nParameters: \n"
+            + "1. " + PREFIX_WORKER_OLD + "OLD_WORKER_INDEX (must be a positive integer) "
             + PREFIX_WORKER_NEW + "NEW_WORKER_INDEX (must be a positive integer "
             + PREFIX_SHIFT_OLD + "OLD_SHIFT_INDEX (must be a positive integer) "
             + PREFIX_SHIFT_NEW + "NEW_SHIFT_INDEX (must be a positive integer) "
             + PREFIX_ROLE + "ROLE\n"
-            + "Example: " + COMMAND_WORD
+            + "2. " + PREFIX_WORKER + "WORKER_INDEX (must be a positive integer) "
+            + PREFIX_SHIFT + "SHIFT_INDEX (must be a positive integer) "
+            + PREFIX_ROLE + "ROLE\n"
+            + "Examples:\n" + COMMAND_WORD
             + " wo/1 "
             + "wn/2 "
             + "so/1 "
             + "sn/2 "
-            + "r/Cashier";
+            + "r/Cashier\n"
+            + COMMAND_WORD + " w/1 s/1 r/Chef";
 
     public static final String MESSAGE_REASSIGN_SUCCESS = "Reassignment made:\n%1$s";
     public static final String MESSAGE_DUPLICATE_ASSIGNMENT = "This assignment already exists in the McScheduler";

--- a/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/ReassignCommand.java
@@ -39,6 +39,7 @@ public class ReassignCommand extends Command {
 
     public static final String MESSAGE_REASSIGN_SUCCESS = "Reassignment made:\n%1$s";
     public static final String MESSAGE_DUPLICATE_ASSIGNMENT = "This assignment already exists in the McScheduler";
+    public static final String MESSAGE_EXISTING_ASSIGNMENT = "%1$s is already assigned to a role in the shift.";
     public static final String MESSAGE_ASSIGNMENT_NOT_FOUND = "The assignment to be edited does not exist";
 
     private final Index oldShiftIndex;
@@ -112,9 +113,17 @@ public class ReassignCommand extends Command {
         Shift newShift = lastShownShiftList.get(newShiftIndex.getZeroBased());
         Assignment assignmentToAdd = new Assignment(newShift, newWorker, newRole);
 
-        if (model.hasAssignment(assignmentToAdd)
+        // For cases where reassign is done on same worker in same shift, role needs to be checked
+        // Duplicate assignment if role is the same
+        if (oldWorker.equals(newWorker) && oldShift.equals(newShift) && model.hasAssignment(assignmentToAdd)
                 && assignmentToAdd.getRole().equals(assignmentToRemove.getRole())) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
+        }
+
+        // For cases where reassign is called on different shifts and workers
+        // Only check whether a worker is already assigned to a role in a shift
+        if ((!(oldWorker.equals(newWorker)) || !(oldShift.equals(newShift))) && model.hasAssignment(assignmentToAdd)) {
+            throw new CommandException(String.format(MESSAGE_EXISTING_ASSIGNMENT, newWorker.getName()));
         }
 
         if (!newWorker.isFitForRole(newRole)) {

--- a/src/main/java/mcscheduler/logic/parser/ParserUtil.java
+++ b/src/main/java/mcscheduler/logic/parser/ParserUtil.java
@@ -36,6 +36,14 @@ public class ParserUtil {
     }
 
     /**
+     * Returns true if none of the prefixes have {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesAbsent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isEmpty());
+    }
+
+    /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).

--- a/src/main/java/mcscheduler/logic/parser/ParserUtil.java
+++ b/src/main/java/mcscheduler/logic/parser/ParserUtil.java
@@ -36,10 +36,18 @@ public class ParserUtil {
     }
 
     /**
+     * Returns true if any of the prefixes have {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean notAllPrefixesAbsent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
      * Returns true if none of the prefixes have {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
-    public static boolean arePrefixesAbsent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+    public static boolean allPrefixesAbsent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isEmpty());
     }
 

--- a/src/main/java/mcscheduler/logic/parser/ReassignCommandParser.java
+++ b/src/main/java/mcscheduler/logic/parser/ReassignCommandParser.java
@@ -8,6 +8,7 @@ import static mcscheduler.logic.parser.CliSyntax.PREFIX_SHIFT_OLD;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_NEW;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_OLD;
+import static mcscheduler.logic.parser.ParserUtil.arePrefixesAbsent;
 import static mcscheduler.logic.parser.ParserUtil.arePrefixesPresent;
 
 import mcscheduler.commons.core.Messages;
@@ -31,8 +32,16 @@ public class ReassignCommandParser implements Parser<ReassignCommand> {
                 PREFIX_ROLE, PREFIX_WORKER, PREFIX_SHIFT);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
-                PREFIX_SHIFT_NEW, PREFIX_ROLE)) {
-            if (!arePrefixesPresent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER)) {
+                PREFIX_SHIFT_NEW)) {
+            if (!arePrefixesAbsent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER, PREFIX_ROLE)) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
+            }
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER, PREFIX_ROLE)) {
+            if (!arePrefixesAbsent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
+                    PREFIX_SHIFT_NEW)) {
                 throw new ParseException(
                         String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
             }

--- a/src/main/java/mcscheduler/logic/parser/ReassignCommandParser.java
+++ b/src/main/java/mcscheduler/logic/parser/ReassignCommandParser.java
@@ -8,8 +8,9 @@ import static mcscheduler.logic.parser.CliSyntax.PREFIX_SHIFT_OLD;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_NEW;
 import static mcscheduler.logic.parser.CliSyntax.PREFIX_WORKER_OLD;
-import static mcscheduler.logic.parser.ParserUtil.arePrefixesAbsent;
+import static mcscheduler.logic.parser.ParserUtil.allPrefixesAbsent;
 import static mcscheduler.logic.parser.ParserUtil.arePrefixesPresent;
+import static mcscheduler.logic.parser.ParserUtil.notAllPrefixesAbsent;
 
 import mcscheduler.commons.core.Messages;
 import mcscheduler.commons.core.index.Index;
@@ -31,20 +32,37 @@ public class ReassignCommandParser implements Parser<ReassignCommand> {
                 PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD, PREFIX_SHIFT_NEW,
                 PREFIX_ROLE, PREFIX_WORKER, PREFIX_SHIFT);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
+        if (arePrefixesPresent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
                 PREFIX_SHIFT_NEW)) {
-            if (!arePrefixesAbsent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER, PREFIX_ROLE)) {
+            if (notAllPrefixesAbsent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER)) {
                 throw new ParseException(
                         String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
             }
         }
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER, PREFIX_ROLE)) {
-            if (!arePrefixesAbsent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
+        if (arePrefixesPresent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER)) {
+            if (notAllPrefixesAbsent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
                     PREFIX_SHIFT_NEW)) {
                 throw new ParseException(
                         String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
             }
+        }
+        if (allPrefixesAbsent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER)) {
+            if (!arePrefixesPresent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
+                    PREFIX_SHIFT_NEW)) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
+            }
+        }
+        if (allPrefixesAbsent(argMultimap, PREFIX_WORKER_OLD, PREFIX_WORKER_NEW, PREFIX_SHIFT_OLD,
+                PREFIX_SHIFT_NEW)) {
+            if (!arePrefixesPresent(argMultimap, PREFIX_SHIFT, PREFIX_WORKER)) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
+            }
+        }
+        if (!arePrefixesPresent(argMultimap, PREFIX_ROLE)) {
+            throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ReassignCommand.MESSAGE_USAGE));
         }
 
         Index oldShiftIndex;

--- a/src/test/java/mcscheduler/logic/commands/ReassignCommandTest.java
+++ b/src/test/java/mcscheduler/logic/commands/ReassignCommandTest.java
@@ -133,7 +133,9 @@ public class ReassignCommandTest {
         Model model = new ModelManager(McSchedulerBuilder.getTypicalMcSchedulerWithAssignments(), new UserPrefs());
         ReassignCommand reassignCommand = new ReassignCommand(INDEX_THIRD_WORKER, INDEX_SECOND_WORKER,
                 INDEX_THIRD_SHIFT, INDEX_THIRD_SHIFT, Role.createRole(VALID_ROLE_JANITOR));
-        Assert.assertThrows(CommandException.class, Messages.MESSAGE_INVALID_ASSIGNMENT_WORKER_ROLE, () ->
+        Worker workerToReassignTo = TestUtil.getWorker(model, INDEX_SECOND_WORKER);
+        Assert.assertThrows(CommandException.class, String.format(Messages.MESSAGE_INVALID_ASSIGNMENT_WORKER_ROLE,
+                workerToReassignTo.getName(), Role.createRole(VALID_ROLE_JANITOR)), () ->
                 reassignCommand.execute(model));
     }
 
@@ -142,8 +144,10 @@ public class ReassignCommandTest {
         Model model = new ModelManager(McSchedulerBuilder.getTypicalMcSchedulerWithAssignments(), new UserPrefs());
         ReassignCommand reassignCommand = new ReassignCommand(INDEX_THIRD_WORKER, INDEX_FIRST_WORKER, INDEX_THIRD_SHIFT,
                 INDEX_THIRD_SHIFT, Role.createRole(VALID_ROLE_CASHIER));
-
-        Assert.assertThrows(CommandException.class, Messages.MESSAGE_INVALID_ASSIGNMENT_UNAVAILABLE, () ->
+        Worker workerToReassignTo = TestUtil.getWorker(model, INDEX_FIRST_WORKER);
+        Shift shiftToReassignTo = TestUtil.getShift(model, INDEX_THIRD_SHIFT);
+        Assert.assertThrows(CommandException.class, String.format(Messages.MESSAGE_INVALID_ASSIGNMENT_UNAVAILABLE,
+                workerToReassignTo.getName(), shiftToReassignTo), () ->
                 reassignCommand.execute(model));
     }
 

--- a/src/test/java/mcscheduler/logic/parser/ReassignCommandParserTest.java
+++ b/src/test/java/mcscheduler/logic/parser/ReassignCommandParserTest.java
@@ -17,6 +17,8 @@ import static mcscheduler.logic.commands.CommandTestUtil.VALID_OLD_SHIFT_INDEX_1
 import static mcscheduler.logic.commands.CommandTestUtil.VALID_OLD_WORKER_INDEX_1;
 import static mcscheduler.logic.commands.CommandTestUtil.VALID_ROLE_CASHIER;
 import static mcscheduler.logic.commands.CommandTestUtil.VALID_ROLE_CHEF;
+import static mcscheduler.logic.commands.CommandTestUtil.VALID_SHIFT_INDEX_1;
+import static mcscheduler.logic.commands.CommandTestUtil.VALID_WORKER_INDEX_1;
 import static mcscheduler.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static mcscheduler.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static mcscheduler.testutil.TypicalIndexes.INDEX_FIRST_SHIFT;
@@ -65,6 +67,12 @@ public class ReassignCommandParserTest {
                 + VALID_NEW_SHIFT_INDEX_2 + ROLE_DESC_CASHIER + ROLE_DESC_CHEF,
                 new ReassignCommand(INDEX_FIRST_WORKER, INDEX_SECOND_WORKER, INDEX_FIRST_SHIFT, INDEX_SECOND_SHIFT,
                         Role.createRole(VALID_ROLE_CHEF)));
+
+        // worker index and shift index provided for reassign within 1 shift
+        assertParseSuccess(parser, VALID_OLD_WORKER_INDEX_1 + VALID_NEW_WORKER_INDEX_2 + VALID_OLD_SHIFT_INDEX_1
+                        + VALID_NEW_SHIFT_INDEX_2 + ROLE_DESC_CASHIER + ROLE_DESC_CHEF,
+                new ReassignCommand(INDEX_FIRST_WORKER, INDEX_SECOND_WORKER, INDEX_FIRST_SHIFT, INDEX_SECOND_SHIFT,
+                        Role.createRole(VALID_ROLE_CHEF)));
     }
 
     @Test
@@ -90,6 +98,12 @@ public class ReassignCommandParserTest {
         // missing role prefix
         assertParseFailure(parser, VALID_OLD_WORKER_INDEX_1 + VALID_NEW_WORKER_INDEX_2 + VALID_OLD_SHIFT_INDEX_1
                 + VALID_NEW_SHIFT_INDEX_2, expectedMessage);
+
+        // missing shift index for 3-parameter format
+        assertParseFailure(parser, VALID_WORKER_INDEX_1 + ROLE_DESC_CASHIER, expectedMessage);
+
+        // missing shift index for 3-parameter format
+        assertParseFailure(parser, VALID_SHIFT_INDEX_1 + ROLE_DESC_CASHIER, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, INDEX_FIRST_SHIFT + " " + INDEX_FIRST_WORKER + VALID_ROLE_CASHIER, expectedMessage);


### PR DESCRIPTION
Resolves #169
Now users can use the command `reassign s/SHIFT_INDEX w/WORKER_INDEX r/NEW_ROLE` if they want to reassign a worker's role within a shift 