### PR TITLE
Stops execution of take-leave if one of the workers is already on leave and improved error message thrown by cancel-leave

### DIFF
--- a/src/main/java/mcscheduler/logic/commands/CancelLeaveCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/CancelLeaveCommand.java
@@ -85,14 +85,14 @@ public class CancelLeaveCommand extends Command {
 
             Optional<Assignment> assignmentInModelOptional = model.getAssignment(assignmentToCancelLeave);
             if (assignmentInModelOptional.isEmpty()) {
-                throw new CommandException(String.format(Messages.MESSAGE_NO_ASSIGNMENT_FOUND,
-                        workerToCancelLeave, shiftToCancelLeaveFrom));
+                throw new CommandException(String.format(MESSAGE_WORKER_NOT_ON_LEAVE,
+                        workerToCancelLeave.getName(), workerIndex.getOneBased()));
             }
 
             Assignment assignmentInModel = assignmentInModelOptional.get();
             if (!Leave.isLeave(assignmentInModel.getRole())) {
-                throw new CommandException(String.format(Messages.MESSAGE_NO_LEAVE_FOUND,
-                        workerToCancelLeave, shiftToCancelLeaveFrom));
+                throw new CommandException(String.format(MESSAGE_WORKER_NOT_ON_LEAVE,
+                        workerToCancelLeave.getName(), workerIndex.getOneBased()));
             }
 
             try {
@@ -106,30 +106,6 @@ public class CancelLeaveCommand extends Command {
 
         return new CommandResult(String.format(
                 MESSAGE_CANCEL_LEAVE_SUCCESS, workerIndexes.size(), assignStringBuilder.toString()));
-    }
-
-    private void checkWorkerNotOnLeave(Model model) throws CommandException {
-        List<Worker> lastShownList = model.getFilteredWorkerList();
-        List<Assignment> assignmentList = model.getFullAssignmentList();
-
-        for (Index workerIndex : workerIndexes) {
-            Worker worker = lastShownList.get(workerIndex.getZeroBased());
-            boolean isWorkerOnLeave = false;
-            for (Assignment assignment : assignmentList) {
-                if (!assignment.getWorker().isSameWorker(worker)) {
-                    continue;
-                }
-                if (Leave.isLeave(assignment.getRole())) {
-                    isWorkerOnLeave = true;
-                    break;
-                }
-            }
-            if (!isWorkerOnLeave) {
-                throw new CommandException(
-                        String.format(MESSAGE_WORKER_NOT_ON_LEAVE, worker.getName(),
-                                workerIndex.getOneBased()));
-            }
-        }
     }
 
     @Override

--- a/src/main/java/mcscheduler/logic/commands/TakeLeaveCommand.java
+++ b/src/main/java/mcscheduler/logic/commands/TakeLeaveCommand.java
@@ -63,7 +63,7 @@ public class TakeLeaveCommand extends Command {
         List<Index> workerToReplaceAssignmentIndexes = new ArrayList<>();
         separateWorkerIndexes(workerToTakeLeavePairs, workerToReplaceAssignmentIndexes, model);
 
-        checkWorkerAlreadyOnLeave(model);
+        checkWorkerAlreadyOnLeave(model, shiftIndex);
 
         CommandResult assignCommandResult = new CommandResult("");
         if (!workerToTakeLeavePairs.isEmpty()) {
@@ -112,14 +112,16 @@ public class TakeLeaveCommand extends Command {
         }
     }
 
-    private void checkWorkerAlreadyOnLeave(Model model) throws CommandException {
-        List<Worker> lastShownList = model.getFilteredWorkerList();
+    private void checkWorkerAlreadyOnLeave(Model model, Index shiftIndex) throws CommandException {
+        List<Worker> lastShownWorkerList = model.getFilteredWorkerList();
+        List<Shift> lastShownShiftList = model.getFilteredShiftList();
         List<Assignment> assignmentList = model.getFullAssignmentList();
 
         for (Index workerIndex : workerIndexes) {
-            Worker worker = lastShownList.get(workerIndex.getZeroBased());
+            Worker worker = lastShownWorkerList.get(workerIndex.getZeroBased());
+            Shift shift = lastShownShiftList.get(shiftIndex.getZeroBased());
             for (Assignment assignment : assignmentList) {
-                if (!assignment.getWorker().isSameWorker(worker)) {
+                if (!assignment.getWorker().isSameWorker(worker) || !assignment.getShift().isSameShift(shift)) {
                     continue;
                 }
                 if (Leave.isLeave(assignment.getRole())) {


### PR DESCRIPTION
Stops execution of take-leave if one of the workers is already on leave and improved error message thrown by cancel-leave if worker is not on leave

take-leave s/1 w/1 w/2: 
`Alex Yeoh ( w/1 ) is already on leave. Please remove Alex Yeoh from the "take-leave" command`

cancel-leave s/1 w/1 w/2:
`Bernice Yu ( w/2 ) is not on leave. Please remove Bernice Yu from the "cancel-leave" command`

resolves #254 